### PR TITLE
Updating Route53 to use CNAME

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+example/dev.yaml

--- a/lib/destroy.js
+++ b/lib/destroy.js
@@ -21,7 +21,7 @@ module.exports = function(config, allDone) {
       ec2.terminate(results.instance.InstanceId, done);
     }],
     dns: ['instance', (results, done) => {
-      if (config.host) {
+      if (config.host && config.ec2.route53 !== false) {
         return route53.run(results.instance.PublicIpAddress, 'remove', done);
       }
 

--- a/lib/destroy.js
+++ b/lib/destroy.js
@@ -21,7 +21,7 @@ module.exports = function(config, allDone) {
       ec2.terminate(results.instance.InstanceId, done);
     }],
     dns: ['instance', (results, done) => {
-      if (this.config.host) {
+      if (config.host) {
         return route53.run(results.instance.PublicIpAddress, 'remove', done);
       }
 

--- a/lib/ec2.js
+++ b/lib/ec2.js
@@ -171,13 +171,13 @@ touch /tmp/provision_complete`;
         done(null, instance.PublicDnsName);
       }],
 
-      //dns: ['host', (results, done) => {
-        //if (this.config.host) {
-          //return this.route53.run(results.host, 'create', done);
-        //}
+      dns: ['host', (results, done) => {
+        if (this.config.host) {
+          return this.route53.run(results.host, 'create', done);
+        }
 
-        //done();
-      //}],
+        done();
+      }],
 
       canSSH: ['host', (results, done) => {
         let current = 0;

--- a/lib/ec2.js
+++ b/lib/ec2.js
@@ -172,7 +172,7 @@ touch /tmp/provision_complete`;
       }],
 
       dns: ['host', (results, done) => {
-        if (this.config.host) {
+        if (this.config.host && this.config.ec2.route53 !== false) {
           return this.route53.run(results.host, 'create', done);
         }
 

--- a/lib/route53.js
+++ b/lib/route53.js
@@ -78,11 +78,11 @@ class Route53 {
             Action: action,
             ResourceRecordSet: {
               Name: `*.${domain}`,
-              Type: 'A',
+              Type: 'CNAME',
               TTL: 86400,
               ResourceRecords: [
                 {
-                  Value: ip
+                  Value: domain
                 }
               ]
             }


### PR DESCRIPTION
This issue turns out to be simpler than I thought - though it confused me for a little bit.

The DNS Update already uses an "UPSERT" meaning if the record exists, update it, if not create it. However, I had been setting both records as `A` records and on `leanin.org` we had been using one as an `A` record and one as a `CNAME`. The confusion was that Route53 wouldn't be able to do anything with an `A` record since a `CNAME` one already existed.

I also fixed one bug that I found on the destroy code.

Also - we need a README.